### PR TITLE
Fixed font-size restrictions

### DIFF
--- a/svg.xsd
+++ b/svg.xsd
@@ -268,17 +268,7 @@
                 inherit
             </xs:documentation>
         </xs:annotation>
-        <xs:union>
-            <xs:simpleType>
-                <xs:restriction base="xs:string">
-                    <xs:enumeration value="absolute-size"/>
-                    <xs:enumeration value="relative-size"/>
-                    <xs:enumeration value="length"/>
-                    <xs:enumeration value="percentage"/>
-                    <xs:enumeration value="inherit"/>
-                </xs:restriction>
-            </xs:simpleType>
-        </xs:union>
+        <xs:restriction base="xs:string"/>
     </xs:simpleType>
     <xs:simpleType name="FontSizeAdjustValueType">
         <xs:annotation>


### PR DESCRIPTION
Let specify `font-size="75%"`
```xml
       <svg:tspan dy="4.5" font-size="75%">
        text
       </svg:tspan>
```